### PR TITLE
Added Congo (DRC), to replace Zaire and Timor-Leste, South Sudan

### DIFF
--- a/countries-sql
+++ b/countries-sql
@@ -1,11 +1,3 @@
--- phpMyAdmin SQL Dump
--- version 4.5.2
--- http://www.phpmyadmin.net
---
--- Host: 127.0.0.1
--- Generation Time: Jul 28, 2017 at 10:14 AM
--- Server version: 5.7.9-log
--- PHP Version: 7.0.0
 
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
@@ -17,12 +9,6 @@ SET time_zone = "+00:00";
 /*!40101 SET NAMES utf8mb4 */;
 
 --
--- Database: `rawjobs`
---
-
--- --------------------------------------------------------
-
---
 -- Table structure for table `countries`
 --
 
@@ -32,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `countries` (
   `code` varchar(2) NOT NULL DEFAULT '',
   `name` varchar(100) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=246 DEFAULT CHARSET=utf8;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `countries`
@@ -88,6 +74,7 @@ INSERT INTO `countries` (`id`, `code`, `name`) VALUES
 (47, 'CO', 'Colombia'),
 (48, 'KM', 'Comoros'),
 (49, 'CG', 'Congo'),
+'CD', 'Congo, the Democratic Republic of the'
 (50, 'CK', 'Cook Islands'),
 (51, 'CR', 'Costa Rica'),
 (52, 'HR', 'Croatia (Hrvatska)'),
@@ -240,6 +227,7 @@ INSERT INTO `countries` (`id`, `code`, `name`) VALUES
 (199, 'SO', 'Somalia'),
 (200, 'ZA', 'South Africa'),
 (201, 'GS', 'South Georgia South Sandwich Islands'),
+'SS', 'South Sudan'
 (202, 'ES', 'Spain'),
 (203, 'LK', 'Sri Lanka'),
 (204, 'SH', 'St. Helena'),
@@ -255,6 +243,7 @@ INSERT INTO `countries` (`id`, `code`, `name`) VALUES
 (214, 'TJ', 'Tajikistan'),
 (215, 'TZ', 'Tanzania, United Republic of'),
 (216, 'TH', 'Thailand'),
+'TL', 'Timor-Leste'
 (217, 'TG', 'Togo'),
 (218, 'TK', 'Tokelau'),
 (219, 'TO', 'Tonga'),
@@ -281,7 +270,7 @@ INSERT INTO `countries` (`id`, `code`, `name`) VALUES
 (240, 'WF', 'Wallis and Futuna Islands'),
 (241, 'EH', 'Western Sahara'),
 (242, 'YE', 'Yemen'),
-(243, 'ZR', 'Zaire'),
+-- (243, 'ZR', 'Zaire'),
 (244, 'ZM', 'Zambia'),
 (245, 'ZW', 'Zimbabwe');
 


### PR DESCRIPTION
You currently have two unique fields, the autoincrementing integer and the two letter code. I advise that you drop the integer (it isn't standard) so as to encourage people to use the two letter code.